### PR TITLE
Fix response bodies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+* 0.0.2
+
+  - Make testing layer actually return the headers and bodies that
+    are programmatically added via ``glinda.testing.services.Response``.
+
 * 0.0.1
 
   - Add :class:`glinda.testing.services.Service`

--- a/glinda/__init__.py
+++ b/glinda/__init__.py
@@ -1,2 +1,2 @@
-version_info = (0, 0, 1)
+version_info = (0, 0, 2)
 __version__ = '.'.join(str(x) for x in version_info)

--- a/glinda/testing/services.py
+++ b/glinda/testing/services.py
@@ -306,7 +306,7 @@ class Service(object):
             for request in self._requests[resource]:
                 yield request
         else:
-            raise AssertionError('Expected request for {}'.format(resource))
+            raise AssertionError('Expected request for {0}'.format(resource))
 
     def get_request(self, *path):
         """Convenience method to fetch a single request."""
@@ -328,7 +328,7 @@ class Service(object):
             if request.method == method and request.query == query:
                 return
         else:
-            raise AssertionError('Expected request for {}'.format(resource))
+            raise AssertionError('Expected request for {0}'.format(resource))
 
 
 class _Application(web.Application):

--- a/glinda/testing/services.py
+++ b/glinda/testing/services.py
@@ -385,6 +385,11 @@ class _ServiceHandler(web.RequestHandler):
     def _do_request(self, *args, **kwargs):
         response = self.service.get_next_response(self.request)
         self.set_status(response.status, response.reason)
+        for name, value in response.headers.items():
+            self.set_header(name, value)
+        if response.body:
+            self.write(response.body)
+        self.finish()
 
     connect = _do_request
     delete = _do_request

--- a/tests/example_test.py
+++ b/tests/example_test.py
@@ -101,5 +101,5 @@ class HandlerTests(tornado.testing.AsyncHTTPTestCase):
             services.Response(200, body='foo', headers={'Custom': 'header'}))
 
         response = self.fetch('/do-the-things')
-        self.assertEqual(response.body, 'foo')
+        self.assertEqual(response.body.decode(), 'foo')
         self.assertEqual(response.headers['Custom'], 'header')

--- a/tests/example_test.py
+++ b/tests/example_test.py
@@ -28,16 +28,20 @@ class MyHandler(web.RequestHandler):
     def get(self):
         netloc = os.environ['SERVICE_NETLOC']
         client = httpclient.AsyncHTTPClient()
-        response = yield client.fetch('http://{0}/status'.format(netloc),
-                                      method='HEAD', raise_error=False)
-        if response.code >= 300:
-            raise web.HTTPError(504)
+        try:
+            yield client.fetch('http://{0}/status'.format(netloc),
+                               method='HEAD')
+        except web.HTTPError as error:
+            if error.code >= 300:
+                raise web.HTTPError(504)
 
-        response = yield client.fetch('http://{0}/do-stuff'.format(netloc),
-                                      method='POST', raise_error=False,
-                                      body='important stuff')
-        if response.code >= 300:
-            raise web.HTTPError(500)
+        try:
+            response = yield client.fetch('http://{0}/do-stuff'.format(netloc),
+                                          method='POST',
+                                          body='important stuff')
+        except web.HTTPError as error:
+            if error.code >= 300:
+                raise web.HTTPError(500)
 
         self.set_status(200)
         self.set_header('Custom', response.headers.get('Custom', ''))


### PR DESCRIPTION
Body and header values passed to `glinda.testing.services.Response` were not being correctly returned to the service under test.
