### PR TITLE
Avoid double-quoting the resource path

### DIFF
--- a/glinda/testing/services.py
+++ b/glinda/testing/services.py
@@ -210,10 +210,17 @@ class Service(object):
         :meth:`.add_response` which will create the resource if necessary.
 
         """
-        url = _quote_path(*path)
-        if url not in self._endpoints:
-            self.add_resource_callback(self, url)
-            self._endpoints.add(url)
+        self._register_endpoint(_quote_path(*path))
+
+    def _register_endpoint(self, path):
+        """
+        Register an endpoint with with this service.
+
+        :param path: quoted resource path
+        """
+        if path not in self._endpoints:
+            self.add_resource_callback(self, path)
+            self._endpoints.add(path)
 
     def add_response(self, request, response):
         """
@@ -224,7 +231,7 @@ class Service(object):
             handler receives `request`
 
         """
-        self.add_endpoint(request.resource)
+        self._register_endpoint(request.resource)
         self._responses[request.method, request.resource].append(response)
 
     def record_request(self, request):

--- a/tests/testing_tests.py
+++ b/tests/testing_tests.py
@@ -65,11 +65,11 @@ class EndpointTests(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_that_endpoint_responds_with_programmed_response(self):
         service = self.service_layer['service']
-        service.add_response(services.Request('GET', '/resource'),
+        service.add_response(services.Request('GET', '/resource:test'),
                              services.Response(222))
 
         client = httpclient.AsyncHTTPClient()
-        response = yield client.fetch(service.url_for('resource'))
+        response = yield client.fetch(service.url_for('resource:test'))
         self.assertEqual(response.code, 222)
 
 


### PR DESCRIPTION
The Request instance passed to add_response is quoted upon creation. When add_response invokes add_endpoint, the URL is quoted a second time. Thus, a _private_ method was created solely to register the endpoint without quoting.