### PR TITLE
Insert handlers before the default error handler.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog
   - Add directory of examples
   - Remove support for tornado newer than 4.5.  *This is tempory due to changes
     in the Tornado API*.
+  - Change Application.add_resource so that it inserts handlers before the
+    default error handler instead of after.
 
 * `0.0.3`_ (30 May 2015)
 

--- a/glinda/testing/services.py
+++ b/glinda/testing/services.py
@@ -367,7 +367,8 @@ class _Application(web.Application):
         """
         handler = web.url(resource, _ServiceHandler,
                           kwargs={'service': service})
-        self.handlers[-1][1].append(handler)
+        # leave the error handler at the end
+        self.handlers[-1][1].insert(-1, handler)
 
 
 class _ServiceHandler(web.RequestHandler):


### PR DESCRIPTION
This makes it possible to add a handler that uses the root path.